### PR TITLE
Upgrade overthere to 2.4.8 and property to set usage of kerberos cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.ipr
 *.iml
 *.sublime*
+/bin/

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    pluginLibs(group: 'com.xebialabs.overthere', name: 'overthere', version: '2.4.2'){
+    pluginLibs(group: 'com.xebialabs.overthere', name: 'overthere', version: '2.4.8'){
         exclude( module: 'bcprov-jdk16')
         exclude( module: 'jzlib')
         exclude( module: 'sshj')
@@ -47,7 +47,7 @@ dependencies {
     pluginLibs(group: 'org.slf4j', name: 'slf4j-nop', version: '1.6.3')
     //nb: commons-codec 1.6 is a transitive of overthere 2.2.2 via httpclient 4.2.1. but maven only uses explicit deps, and overthere 2.2.2 declares 1.5
     //TODO: remove this explicit dep after updating overthere to 2.2.3+
-//    pluginLibs(group: 'commons-codec', name: 'commons-codec', version: '1.6')
+ //   pluginLibs(group: 'commons-codec', name: 'commons-codec', version: '1.6')
 
     compile(group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
               <Rundeck-Plugin-File-Version>1.2-SNAPSHOT</Rundeck-Plugin-File-Version>
               <Rundeck-Plugin-Archive>true</Rundeck-Plugin-Archive>
               <Rundeck-Plugin-Classnames>com.dtolabs.rundeck.plugin.overthere.OTWinRMNodeExecutor</Rundeck-Plugin-Classnames>
-              <Rundeck-Plugin-Libs>lib/overthere-2.4.2.jar lib/slf4j-nop-1.6.3.jar lib/jcifs-1.3.17.jar lib/commons-codec-1.6.jar lib/httpcore-4.2.1.jar lib/guava-16.0.1.jar lib/slf4j-api-1.6.3.jar lib/httpclient-4.2.1.jar lib/annotations-1.0.0.jar lib/truezip-swing-7.3.4.jar lib/commons-compress-1.2.jar lib/truezip-driver-zip-7.3.4.jar lib/truezip-kernel-7.3.4.jar lib/javassist-3.15.0-GA.jar lib/truezip-file-7.3.4.jar lib/scannit-1.2.1.jar lib/truezip-driver-file-7.3.4.jar</Rundeck-Plugin-Libs>
+              <Rundeck-Plugin-Libs>lib/overthere-2.4.8.jar lib/slf4j-nop-1.6.3.jar lib/jcifs-1.3.17.jar lib/commons-codec-1.6.jar lib/httpcore-4.2.1.jar lib/guava-16.0.1.jar lib/slf4j-api-1.6.3.jar lib/httpclient-4.2.1.jar lib/annotations-1.0.0.jar lib/truezip-swing-7.3.4.jar lib/commons-compress-1.2.jar lib/truezip-driver-zip-7.3.4.jar lib/truezip-kernel-7.3.4.jar lib/javassist-3.15.0-GA.jar lib/truezip-file-7.3.4.jar lib/scannit-1.2.1.jar lib/truezip-driver-file-7.3.4.jar</Rundeck-Plugin-Libs>
             </manifestEntries>
           </archive>
         </configuration>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>com.xebialabs.overthere</groupId>
       <artifactId>overthere</artifactId>
-      <version>2.4.2</version>
+      <version>2.4.8</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/dtolabs/rundeck/plugin/overthere/OTWinRMNodeExecutor.java
+++ b/src/main/java/com/dtolabs/rundeck/plugin/overthere/OTWinRMNodeExecutor.java
@@ -66,6 +66,7 @@ public class OTWinRMNodeExecutor implements NodeExecutor, Describable {
     public static final String WINRM_SPN_USE_HTTP = "winrm-spn-use-http";
     public static final String WINRM_LOCALE = "winrm-locale";
     public static final String WINRM_TIMEOUT = "winrm-timeout";
+    
 
     public static final String HOSTNAME_TRUST_BROWSER_COMPATIBLE = "browser-compatible";
     public static final String HOSTNAME_TRUST_STRICT = "strict";
@@ -80,6 +81,8 @@ public class OTWinRMNodeExecutor implements NodeExecutor, Describable {
     public static final String DEBUG_KERBEROS_AUTH = "winrm-kerberos-debug";
     public static final Boolean DEFAULT_DEBUG_KERBEROS_AUTH = false;
     public static final String DEFAULT_WINRM_PROTOCOL = WINRM_PROTOCOL_HTTPS;
+    public static final String KERBEROS_CACHE = "kerberos-cache";
+    public static final Boolean DEFAULT_KERBEROS_CACHE = false;
 
     public static final WinrmHttpsCertificateTrustStrategy DEFAULT_CERT_TRUST =
         WinrmHttpsCertificateTrustStrategy.STRICT;
@@ -484,6 +487,11 @@ public class OTWinRMNodeExecutor implements NodeExecutor, Describable {
         public String getWinrmTimeout() {
             return resolveProperty(WINRM_TIMEOUT, null, getNode(), getFrameworkProject(), getFramework());
         }
+        
+        public Boolean isKerberosCacheEnabled() {
+            return resolveBooleanProperty(KERBEROS_CACHE, DEFAULT_KERBEROS_CACHE, getNode(), getFrameworkProject(),
+                    getFramework());
+        }
 
         private int getPort(final int defaultPort) throws ConfigurationException {
             // If the node entry contains a non-default port, configure the connection to use it.
@@ -511,6 +519,7 @@ public class OTWinRMNodeExecutor implements NodeExecutor, Describable {
                 options.set(CifsConnectionBuilder.WINRM_KERBEROS_DEBUG, isDebugKerberosAuth());
                 options.set(CifsConnectionBuilder.WINRM_KERBEROS_ADD_PORT_TO_SPN, isWinrmSpnAddPort());
                 options.set(CifsConnectionBuilder.WINRM_KERBEROS_USE_HTTP_SPN, isWinrmSpnUseHttp());
+                options.set(CifsConnectionBuilder.WINRM_KERBEROS_TICKET_CACHE, isKerberosCacheEnabled());
             } else {
                 username = getUsername();
             }


### PR DESCRIPTION
Overthere 2.4.8 has support for enabling the use of the kerberos cache for authentication