### PR TITLE
Removal of the slf4j-nop binding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,6 @@ dependencies {
         exclude( module: 'icu4j')
         exclude( module: 'jcl-over-slf4j')
     }
-//    pluginLibs(group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.3')
-    pluginLibs(group: 'org.slf4j', name: 'slf4j-nop', version: '1.6.3')
 
     compile(group: 'org.rundeck', name: 'rundeck-core', version: rundeckVersion)
 }


### PR DESCRIPTION
The plugin uses currently two System.out method calls. The nop binding shouldn't
be provided to the classpath by a plugin.